### PR TITLE
fix: correct off-by-one rank error in points calculation

### DIFF
--- a/components/TournamentCard.js
+++ b/components/TournamentCard.js
@@ -23,7 +23,7 @@ export default function TournamentCard({ tournament, onDelete, onEdit }) {
           /** * LOGIK: Punkte live berechnen
            * Platzierung (index + 1) und die Gesamtanzahl
            */
-          const points = calculatePoints(index + 1, participantCount);
+          const points = calculatePoints(index, participantCount);
 
           return (
             <PlayerBadge key={`${tournament._id}-${player}`} $rank={index + 1}>

--- a/utils/pointsEngine.js
+++ b/utils/pointsEngine.js
@@ -33,12 +33,13 @@ export function getYearlyRanking(tournaments) {
 
     tournament.participants.forEach((name, index) => {
       const points = calculatePoints(index, totalTN);
+      const normalizedName = name.trim();
 
       // Wir kummulieren: Wenn Name schon da, addieren, sonst neu anlegen
-      if (ranking[name]) {
-        ranking[name] += points;
+      if (ranking[normalizedName]) {
+        ranking[normalizedName] += points;
       } else {
-        ranking[name] = points;
+        ranking[normalizedName] = points;
       }
     });
   });


### PR DESCRIPTION
- TournamentCard passed index+1 to calculatePoints (1-based), but the function expects a 0-based index. 1st place received 18 pts instead of 25, 2nd place received 15 instead of 18, etc.
- Add name.trim() in getYearlyRanking to prevent whitespace mismatches from splitting one player into separate ranking entries.