### PR TITLE
feat: add annual ranking percentage calculation

### DIFF
--- a/__tests__/utils/pointsEngine.test.js
+++ b/__tests__/utils/pointsEngine.test.js
@@ -1,4 +1,7 @@
-import { getProcessedRanking } from "@/utils/pointsEngine";
+import {
+  getProcessedRanking,
+  YEARLY_PERCENTAGE_TABLE,
+} from "@/utils/pointsEngine";
 
 // Hilfsfunktion: Erzeugt ein minimales Turnier-Objekt mit beliebigen Teilnehmern.
 // Datum und Monat sind für die Punkteberechnung irrelevant – nur participants zählt.
@@ -60,5 +63,94 @@ describe("getProcessedRanking – Gleichstandsregel", () => {
     expect(ranking[0].displayRank).toBe(1);
     expect(ranking[1].displayRank).toBe(2);
     expect(ranking[2].displayRank).toBe(3);
+  });
+});
+
+describe("YEARLY_PERCENTAGE_TABLE – Prozentuale Verteilung", () => {
+  test("Top 8 Prozentwerte sind korrekt definiert", () => {
+    expect(YEARLY_PERCENTAGE_TABLE).toEqual([
+      25, 20, 13.5, 13.5, 10, 8, 6, 4,
+    ]);
+  });
+});
+
+describe("getProcessedRanking – Jahreswertung Prozentanteil", () => {
+  test("Top 8 Spieler erhalten Prozentanteil, Platz 9+ nicht", () => {
+    // Arrange: 10 Spieler in einem Turnier
+    const participants = Array.from({ length: 10 }, (_, i) => `Spieler${i + 1}`);
+    const tournaments = [makeTournament(participants)];
+
+    // Act
+    const ranking = getProcessedRanking(tournaments);
+
+    // Assert: Top 8 haben Prozentanteil, Platz 9 und 10 nicht
+    for (let i = 0; i < 8; i++) {
+      expect(ranking[i].yearlyPercentage).toBeGreaterThan(0);
+    }
+    expect(ranking[8].yearlyPercentage).toBeNull();
+    expect(ranking[9].yearlyPercentage).toBeNull();
+  });
+
+  test("Prozentanteile entsprechen der Tabelle bei keinem Gleichstand", () => {
+    // Arrange: 8 Spieler mit eindeutigen Plätzen
+    const participants = Array.from({ length: 8 }, (_, i) => `Spieler${i + 1}`);
+    const tournaments = [makeTournament(participants)];
+
+    // Act
+    const ranking = getProcessedRanking(tournaments);
+
+    // Assert: Prozentwerte entsprechen der Tabelle
+    const expectedPercentages = [25, 20, 13.5, 13.5, 10, 8, 6, 4];
+    ranking.forEach((player, index) => {
+      expect(player.yearlyPercentage).toBe(expectedPercentages[index]);
+    });
+  });
+
+  test("Bei geteiltem Platz 1 wird Prozentanteil gemittelt", () => {
+    // Arrange: Zwei Turniere mit umgekehrter Reihenfolge
+    // Tester1 und Tester3 teilen sich Platz 1
+    const tournaments = [
+      makeTournament(["Tester1", "Tester2", "Tester3"]),
+      makeTournament(["Tester3", "Tester2", "Tester1"]),
+    ];
+
+    // Act
+    const ranking = getProcessedRanking(tournaments);
+
+    const tester1 = ranking.find((p) => p.name === "Tester1");
+    const tester3 = ranking.find((p) => p.name === "Tester3");
+    const tester2 = ranking.find((p) => p.name === "Tester2");
+
+    // Assert: Tester1 und Tester3 teilen Platz 1 → (25 + 20) / 2 = 22.5%
+    expect(tester1.yearlyPercentage).toBe(22.5);
+    expect(tester3.yearlyPercentage).toBe(22.5);
+    // Tester2 ist auf Platz 3 → 13.5%
+    expect(tester2.yearlyPercentage).toBe(13.5);
+  });
+
+  test("Bei geteilten Plätzen 3+4 bleibt Prozentanteil gleich", () => {
+    // Arrange: Konstellation wo Platz 3 und 4 geteilt werden
+    // 4 Spieler, 2 Turniere mit spezieller Anordnung
+    const tournaments = [
+      makeTournament(["A", "B", "C", "D"]),
+      makeTournament(["B", "A", "D", "C"]),
+    ];
+
+    // Act
+    const ranking = getProcessedRanking(tournaments);
+
+    // A und B haben gleiche Punkte (geteilter Platz 1)
+    // C und D haben gleiche Punkte (geteilter Platz 3)
+    const playerA = ranking.find((p) => p.name === "A");
+    const playerB = ranking.find((p) => p.name === "B");
+    const playerC = ranking.find((p) => p.name === "C");
+    const playerD = ranking.find((p) => p.name === "D");
+
+    // A und B teilen Platz 1: (25 + 20) / 2 = 22.5%
+    expect(playerA.yearlyPercentage).toBe(22.5);
+    expect(playerB.yearlyPercentage).toBe(22.5);
+    // C und D teilen Platz 3: (13.5 + 13.5) / 2 = 13.5%
+    expect(playerC.yearlyPercentage).toBe(13.5);
+    expect(playerD.yearlyPercentage).toBe(13.5);
   });
 });

--- a/components/YearlyRanking.js
+++ b/components/YearlyRanking.js
@@ -16,6 +16,7 @@ export default function YearlyRanking({ tournaments }) {
             <Th>Platz</Th>
             <Th>Name</Th>
             <Th style={{ textAlign: "right" }}>Punkte</Th>
+            <Th style={{ textAlign: "right" }}>Anteil %</Th>
           </tr>
         </thead>
         <tbody>
@@ -29,6 +30,13 @@ export default function YearlyRanking({ tournaments }) {
               <Td>{player.name}</Td>
               <Td style={{ textAlign: "right", fontWeight: "bold" }}>
                 {player.points}
+              </Td>
+              <Td style={{ textAlign: "right" }}>
+                {player.yearlyPercentage !== null
+                  ? `${player.yearlyPercentage.toFixed(
+                      player.yearlyPercentage % 1 === 0 ? 0 : 1
+                    )} %`
+                  : ""}
               </Td>
             </StyledTableRow>
           ))}

--- a/utils/pointsEngine.js
+++ b/utils/pointsEngine.js
@@ -1,4 +1,10 @@
 /**
+ * Prozentuale Verteilung für die Top 8 der Jahresrangliste
+ * Nur die Top 8 erhalten einen Anteil, Plätze 9+ bleiben leer
+ */
+export const YEARLY_PERCENTAGE_TABLE = [25, 20, 13.5, 13.5, 10, 8, 6, 4];
+
+/**
  * Berechnet die Punkte für einen einzelnen Teilnehmer nach F1-Logik
  * @param {number} rank - Der Platz (0 = 1. Platz, 1 = 2. Platz, etc.)
  * @param {number} totalParticipants - Anzahl aller Teilnehmer im Turnier
@@ -51,14 +57,54 @@ export function getYearlyRanking(tournaments) {
 }
 
 /**
+ * Berechnet den prozentualen Anteil für einen Spieler basierend auf seinem Rang
+ * Berücksichtigt Gleichstand: Bei geteilten Plätzen werden die Prozente gemittelt
+ * @param {number} displayRank - Der angezeigte Rang (1-basiert)
+ * @param {Array} ranking - Das vollständige Ranking zur Gleichstandserkennung
+ * @param {number} playerIndex - Index im Ranking-Array
+ * @returns {number|null} Prozentualer Anteil oder null für Plätze 9+
+ */
+function calculateYearlyPercentage(displayRank, ranking, playerIndex) {
+  // Nur Top 8 erhalten Prozentanteil
+  if (displayRank > 8) {
+    return null;
+  }
+
+  // Finde alle Spieler mit demselben Rang (Gleichstand)
+  const tiedPlayers = ranking.filter(
+    (p, idx) => p.displayRank === displayRank
+  );
+  const tiedCount = tiedPlayers.length;
+
+  if (tiedCount === 1) {
+    // Kein Gleichstand – direkter Prozentwert aus Tabelle
+    return YEARLY_PERCENTAGE_TABLE[displayRank - 1] || null;
+  }
+
+  // Gleichstand: Summiere die Prozente aller belegten Positionen und teile durch Anzahl
+  // Beispiel: Geteilter Platz 1 → Positionen 0 und 1 → (25 + 20) / 2 = 22.5%
+  const startIdx = displayRank - 1;
+  let percentageSum = 0;
+  for (let i = 0; i < tiedCount; i++) {
+    const tableIdx = startIdx + i;
+    if (tableIdx < YEARLY_PERCENTAGE_TABLE.length) {
+      percentageSum += YEARLY_PERCENTAGE_TABLE[tableIdx];
+    }
+  }
+
+  return percentageSum / tiedCount;
+}
+
+/**
  * Wendet die Gleichstandsregel an: Spieler mit gleicher Punktzahl erhalten denselben Rang
+ * Berechnet zusätzlich den prozentualen Anteil für die Top 8
  * @param {Array} tournaments - Alle Turnier-Daten
- * @returns {Array} Sortiertes Array mit {name, points, displayRank}
+ * @returns {Array} Sortiertes Array mit {name, points, displayRank, yearlyPercentage}
  */
 export function getProcessedRanking(tournaments) {
   const rawRanking = getYearlyRanking(tournaments);
 
-  return rawRanking.reduce((acc, player, index) => {
+  const rankingWithRanks = rawRanking.reduce((acc, player, index) => {
     const previousPlayer = acc[index - 1];
     let displayRank;
     if (previousPlayer && player.points === previousPlayer.points) {
@@ -69,4 +115,14 @@ export function getProcessedRanking(tournaments) {
     acc.push({ ...player, displayRank });
     return acc;
   }, []);
+
+  // Berechne Prozentanteil für jeden Spieler
+  return rankingWithRanks.map((player, index) => ({
+    ...player,
+    yearlyPercentage: calculateYearlyPercentage(
+      player.displayRank,
+      rankingWithRanks,
+      index
+    ),
+  }));
 }


### PR DESCRIPTION
## Feature Added

### Changes
- ✅ Percentage share in ranking (Top 8 only)
- ✅ Updated display with new 'Anteil %' column
- ✅ German localization ('Anteil %')
- ✅ Tie-breaking logic for shared positions
- ✅ Comprehensive test coverage

### Implementation Details
- Added `YEARLY_PERCENTAGE_TABLE` constant: [25, 20, 13.5, 13.5, 10, 8, 6, 4]
- Updated `getProcessedRanking()` to calculate `yearlyPercentage`
- Added `calculateYearlyPercentage()` function with tie-handling
- Updated `YearlyRanking.js` component to display percentage column

### Test Results
All 8 tests passing:
- Top 8 percentage validation
- Tie-breaking scenarios
- No percentage for positions 9+

Fixes #32