### PR TITLE
fix: Platzierungspunkte als lineare Skala (1 bis N)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,7 @@ const mockTournament = {
 it('zeigt den Gewinner und seine Punkte an', () => {
   render(<TournamentCard tournament={mockTournament} />)
   expect(screen.getByText('Phil Ivey')).toBeInTheDocument()
-  // Punkte werden dynamisch berechnet: 25 (Rang 1) + 3 (3 Teilnehmer) + 5 (Anwesenheit)
+  // Punkte werden dynamisch berechnet: 25 (Rang 1) + 3 (TN-Punkte: N-rank = 3-0) + 5 (Anwesenheit)
   expect(screen.getByText('33 Pts')).toBeInTheDocument()
 })
 ```

--- a/robot/tests/05_yearly_ranking_tie.robot
+++ b/robot/tests/05_yearly_ranking_tie.robot
@@ -24,15 +24,16 @@ Gleichstand in der Jahrestabelle zeigt geteilte Plätze
     ...
     ...                Ausgangslage: Zwei Turniere mit je 3 Testteilnehmern in
     ...                umgekehrter Reihenfolge (Tester1/Tester2/Tester3 und Tester3/Tester2/Tester1).
-    ...                Punkte nach F1-Formel + TN-Anzahl + Anwesenheitsbonus:
-    ...                  Tester1: (25+3+5) + (15+3+5) = 56 Punkte
-    ...                  Tester3: (15+3+5) + (25+3+5) = 56 Punkte → Gleichstand!
-    ...                  Tester2: (18+3+5) + (18+3+5) = 52 Punkte
+    ...                Punkte nach F1-Formel + TN-Punkte (linear) + Anwesenheitsbonus:
+    ...                  Tester1: (25+3+5) + (15+1+5) = 54 Punkte
+    ...                  Tester3: (15+1+5) + (25+3+5) = 54 Punkte → Gleichstand!
+    ...                  Tester2: (18+2+5) + (18+2+5) = 50 Punkte
+    ...                  TN-Punkte linear: Sieger=N, Zweiter=N-1, Letzter=1
     ...
     ...                Erwartetes Ergebnis in der Jahrestabelle:
-    ...                  Platz 1: Tester1 (56 Pkt.)
-    ...                  Platz 1: Tester3 (56 Pkt.)  ← geteilter Platz
-    ...                  Platz 3: Tester2 (52 Pkt.)  ← Platz 2 wird übersprungen
+    ...                  Platz 1: Tester1 (54 Pkt.)
+    ...                  Platz 1: Tester3 (54 Pkt.)  ← geteilter Platz
+    ...                  Platz 3: Tester2 (50 Pkt.)  ← Platz 2 wird übersprungen
     [Tags]    yearly-ranking    tie
     Navigate To Page    /
 

--- a/utils/pointsEngine.js
+++ b/utils/pointsEngine.js
@@ -2,7 +2,7 @@
  * Berechnet die Punkte für einen einzelnen Teilnehmer nach F1-Logik
  * @param {number} rank - Der Platz (0 = 1. Platz, 1 = 2. Platz, etc.)
  * @param {number} totalParticipants - Anzahl aller Teilnehmer im Turnier
- * @returns {number} Die Summe aus Platzierung + TN-Anzahl + Anwesenheit
+ * @returns {number} Die Summe aus Platzierung + TN-Punkte + Anwesenheit
  */
 export function calculatePoints(rank, totalParticipants) {
   // 1. Die Platzierungspunkte (Formel 1 System)
@@ -11,8 +11,9 @@ export function calculatePoints(rank, totalParticipants) {
   // Falls jemand 11. wird, bekommt er 0 Punkte aus der Tabelle
   const rankPoints = rankPointsTable[rank] || 0;
 
-  // 2. TN-Punkte (1 Pkt pro Mitspieler)
-  const participantPoints = totalParticipants;
+  // 2. TN-Punkte: lineare Skala von 1 (Letzter) bis N (Sieger)
+  //    Beispiel bei 10 TN: Sieger = 10, Letzter = 1
+  const participantPoints = totalParticipants - rank;
 
   // 3. Anwesenheits-Bonus (Fixstarter-Punkte)
   const attendancePoints = 5;


### PR DESCRIPTION
## Summary
- Korrigiert die Punkteberechnung in `pointsEngine.js`: Platzierungspunkte sind jetzt eine lineare Skala von 1 (Letzter) bis N (Sieger), nicht mehr ein flacher Bonus für alle
- Aktualisiert die Kommentare in `robot/tests/05_yearly_ranking_tie.robot` (56→54, 52→50)
- Aktualisiert das Beispiel in `CLAUDE.md`

## Formel vorher / nachher
| | Alt | Neu |
|---|---|---|
| Sieger (20 TN) | 25 + **20** + 5 = 50 | 25 + **20** + 5 = 50 ✓ |
| Letzter (20 TN) | 0 + **20** + 5 = 25 ✗ | 0 + **1** + 5 = 6 ✓ |

## Test plan
- [x] Alle 33 Jest-Tests grün
- [ ] Robot Framework Tests auf Testumgebung prüfen (`npm run dev:test` + `npm run test:robot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)